### PR TITLE
Add SSL/TLS reference test code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 node_modules/
+*.pem

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ And point your browser to `http://localhost:3000`. Optionally, specify
 a port by supplying the `PORT` env variable.
 
 NOTE: SSL/TLS (startssl) defaults the port to 3001. Open browser to 
-'https://localhost:3001'. You will have to accept the self-signed warning 
+`https://localhost:3001`. You will have to accept the self-signed warning 
 if used. Older versions of node are known to have issues. This is a way 
 to test your version of node.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 # Socket.IO Fiddle
 
 ```
+$ sh generate.sh # create self-signed keys for server-ssl.js
 $ npm install
 $ npm start # run the server
+$ npm run startssl # run the server over SSL/TLS
 $ npm run client # run the nodejs client
 ```
 
 And point your browser to `http://localhost:3000`. Optionally, specify
 a port by supplying the `PORT` env variable.
+
+NOTE: SSL/TLS (startssl) defaults the port to 3001. Open browser to 
+'https://localhost:3001'. You will have to accept the self-signed warning 
+if used. Older versions of node are known to have issues. This is a way 
+to test your version of node.
+
+**Known versions to work with SSL/TLS: v8.1.3 -- expect newest versions of v6 and v4 to also work (untested)!**

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "You can optionally answer the question, or 'enter' for defaults:"
+openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 3650 -out cert.pem

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "start": "node server.js",
-    "client": "node client.js"
+    "client": "node client.js",
+	"startssl": "node server-ssl.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "scripts": {
     "start": "node server.js",
     "client": "node client.js",
-	"startssl": "node server-ssl.js"
+      "startssl": "node server-ssl.js"
   }
 }

--- a/server-ssl.js
+++ b/server-ssl.js
@@ -1,0 +1,21 @@
+
+const express = require('express');
+const app = express();
+const fs = require('fs');
+const server = require('https').createServer({
+	key: fs.readFileSync('./key.pem'),
+	cert: fs.readFileSync('./cert.pem'),
+}, app);
+const io = require('socket.io')(server);
+const port = process.env.PORT || 3001;
+
+app.use(express.static(__dirname + '/public'));
+
+io.on('connect', onConnect);
+server.listen(port, () => console.log('server listening on port ' + port));
+
+function onConnect(socket) {
+	console.log('connect ' + socket.id);
+
+	socket.on('disconnect', () => console.log('disconnect ' + socket.id));
+}

--- a/server-ssl.js
+++ b/server-ssl.js
@@ -3,8 +3,8 @@ const express = require('express');
 const app = express();
 const fs = require('fs');
 const server = require('https').createServer({
-	key: fs.readFileSync('./key.pem'),
-	cert: fs.readFileSync('./cert.pem'),
+  key: fs.readFileSync('./key.pem'),
+  cert: fs.readFileSync('./cert.pem'),
 }, app);
 const io = require('socket.io')(server);
 const port = process.env.PORT || 3001;
@@ -15,7 +15,7 @@ io.on('connect', onConnect);
 server.listen(port, () => console.log('server listening on port ' + port));
 
 function onConnect(socket) {
-	console.log('connect ' + socket.id);
+  console.log('connect ' + socket.id);
 
-	socket.on('disconnect', () => console.log('disconnect ' + socket.id));
+  socket.on('disconnect', () => console.log('disconnect ' + socket.id));
 }


### PR DESCRIPTION
Spend too much time in figuring out that the problem was with an older version of node **trying** to get socket.io working with https.

Updated the reference test code to include a way to test it. Think this might be useful for others.

--dx9s